### PR TITLE
Fix stonecutter ops setup

### DIFF
--- a/ops/stonecutter/Vagrantfile
+++ b/ops/stonecutter/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 
   config.vm.define "stonecutter", primary: true do |dev|
-    dev.vm.network :forwarded_port, guest: 3000, host: 3000, id: "sso", auto_correct: false
+    dev.vm.network :forwarded_port, guest: 5000, host: 5000, id: "sso", auto_correct: false
 
     dev.vm.provider :virtualbox do |vbox|
       vbox.customize ["modifyvm", :id, "--memory", 2048]

--- a/ops/stonecutter/stonecutter.yml
+++ b/ops/stonecutter/stonecutter.yml
@@ -17,14 +17,16 @@
         - zsh
 
     - name: Create local bin folder
-      file: path=/home/vagrant/bin state=directory
+      file: path=/home/vagrant/bin state=directory owner=vagrant group=vagrant
 
     - name: Downloading lein
-      get_url: dest="/home/vagrant/bin/lein" url=https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein mode=755
+      get_url: dest="/home/vagrant/bin/lein" url=https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein mode=755 owner=vagrant group=vagrant
 
     - name: Cloning Stonecutter source
       git: repo=https://github.com/d-cent/stonecutter.git
            dest=/home/vagrant/stonecutter
+      become: yes
+      become_user: vagrant
 
     - name: add nodesource apt-key
       apt_key: url=https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280 state=present
@@ -56,7 +58,11 @@
     - name: Node.js | Install dependencies
       shell: npm install
         chdir=/home/vagrant/stonecutter
+      become: yes
+      become_user: vagrant
 
     - name: Gulp | Build templates and styles
       shell: gulp build
         chdir=/home/vagrant/stonecutter
+      become: yes
+      become_user: vagrant

--- a/ops/stonecutter/stonecutter.yml
+++ b/ops/stonecutter/stonecutter.yml
@@ -3,7 +3,7 @@
   hosts: stonecutter
 
   tasks:
-    
+
     - name: Running update on pkg repositories
       apt: update_cache=yes
       run_once: true
@@ -16,16 +16,18 @@
         - git
         - zsh
 
-    - command: mkdir -p /home/vagrant/bin
+    - name: Create local bin folder
+      file: path=/home/vagrant/bin state=directory
+
     - name: Downloading lein
       get_url: dest="/home/vagrant/bin/lein" url=https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein mode=755
 
-    - name: Cloning Stonecutter source from local devel/ repository
-      synchronize: src=/home/jrml/devel/stonecutter/ dest=/home/vagrant/stonecutter/
-        archive=yes
+    - name: Cloning Stonecutter source
+      git: repo=https://github.com/d-cent/stonecutter.git
+           dest=/home/vagrant/stonecutter
 
     - name: add nodesource apt-key
-      apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+      apt_key: url=https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280 state=present
 
     - name: add nodesource deb repo
       apt_repository: repo='deb https://deb.nodesource.com/node_0.12 trusty main' state=present


### PR DESCRIPTION
- get rid of the local folder reference
- nodesource moved to CloudFront, updated the apt-key location (see [here](https://github.com/geerlingguy/ansible-role-nodejs/commit/0372961b152fe496412b75316a1a734b4771ad3e))
- (minor) use the `file` ansible module instead of  straight `mkdir`